### PR TITLE
Add CJK compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ retrieves their positions in the PDF, identifies corresponding semantic structur
 3. Guessing the labeling and reading order of unsuccessfully colored words based on line numbers.
 4. Aligned `PyMuPDF` and `pdfplumber` based on position. Now we recognize font flags such as *bold*, _italic_.
 
+[2024-07-01]:
+1. Added fallback XeLaTeX compilation with additional CJK fonts, enabling documents with English, Chinese and Japanese text to compile successfully.
+
 [2024-03-26]: 
 1. Added [de-macro](https://ctan.org/pkg/de-macro?lang=en) preprocessing, which cleans up LaTeX code by expanding a portion of a simple custom macros defined by `\newcommand`, and also inserts `\input` into the main file. This method should increase the success rate of parsing.
 2. Improved conservative parsing strategy for `LatexGroupNode`. We previously didn't color-code them because we were concerned that it was breaking the parameters of the unknown macro. Now we include `LatexGroupNode` with a length of more than 20 characters in the color annotation.

--- a/texcompile/service/Dockerfile
+++ b/texcompile/service/Dockerfile
@@ -5,6 +5,13 @@ RUN apt-get update
 # Set DEBIAN_FRONTEND to disable tzdatainteractive dialogue
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq
+RUN apt-get install -y \
+    fonts-noto-cjk \
+    fonts-noto-cjk-extra \
+    fonts-ipafont-mincho fonts-ipafont-gothic \
+    fonts-arphic-uming fonts-arphic-ukai \
+    fonts-unfonts-core \
+    fonts-noto-color-emoji
 
 # Install Perl
 # Build-essential is required for installing Perl dependencies

--- a/texcompile/service/tests/test_compile.py
+++ b/texcompile/service/tests/test_compile.py
@@ -4,6 +4,8 @@ from lib.compile_autotex import (
     get_compiled_tex_files_from_autotex_output,
     get_errors,
     get_last_autotex_compiler,
+    _contains_cjk,
+    _guess_main_tex,
 )
 
 
@@ -86,3 +88,32 @@ def test_ignore_compilation_failure_for_other_compiler():
     )
     failed = did_compilation_fail(autotex_log, "other-compiler-not-pdflatex")
     assert not failed
+
+
+def test_contains_cjk(tmp_path):
+    tex = tmp_path / "main.tex"
+    tex.write_text("Hello 你好")
+    assert _contains_cjk(str(tmp_path))
+
+
+def test_contains_cjk_false(tmp_path):
+    tex = tmp_path / "main.tex"
+    tex.write_text("Hello world")
+    assert not _contains_cjk(str(tmp_path))
+
+
+def test_guess_main_tex(tmp_path):
+    (tmp_path / "main.tex").write_text("")
+    (tmp_path / "other.tex").write_text("")
+    assert _guess_main_tex(str(tmp_path)) == "main.tex"
+
+
+def test_guess_main_tex_single(tmp_path):
+    (tmp_path / "foo.tex").write_text("")
+    assert _guess_main_tex(str(tmp_path)) == "foo.tex"
+
+
+def test_guess_main_tex_none(tmp_path):
+    (tmp_path / "a.tex").write_text("")
+    (tmp_path / "b.tex").write_text("")
+    assert _guess_main_tex(str(tmp_path)) is None


### PR DESCRIPTION
## Summary
- install CJK fonts in the compilation Dockerfile
- add XeLaTeX fallback logic when AutoTeX fails to compile CJK sources
- document new multilingual compilation capability
- add tests for `_contains_cjk` and `_guess_main_tex`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*