### PR TITLE
Fix html output exception message

### DIFF
--- a/texcompile/client/__init__.py
+++ b/texcompile/client/__init__.py
@@ -175,4 +175,4 @@ def compile_html_return_text(
             contents = base64.b64decode(base64_contents).decode("utf-8")
             return contents
 
-    raise CompilationException('No pdf output.')
+    raise CompilationException("No html output.")


### PR DESCRIPTION
## Summary
- update error string in `compile_html_return_text`

## Testing
- `pytest -q` *(fails: command not found)*